### PR TITLE
Bump org.springframework.boot:spring-boot-starter-parent from 2.5.1 to 2.7.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.1</version>
+        <version>2.7.18</version>
     </parent>
 
     <groupId>io.github.jmkeyes</groupId>


### PR DESCRIPTION
This PR bumps Spring-Boot from 2.5.1 to 2.7.18.