### PR TITLE
Bump org.apache.thrift:libthrift from 0.14.0 to 0.18.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <maven.plugin.source.version>3.3.1</maven.plugin.source.version>
         <maven.plugin.gpg.version>3.2.7</maven.plugin.gpg.version>
 
-        <libthrift.version>0.14.0</libthrift.version>
+        <libthrift.version>0.18.0</libthrift.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This PR bumps Apache Thrift from 0.14.0 to 0.18.0.