### PR TITLE
Add missing Javadocs to ThriftController annotation.

### DIFF
--- a/src/main/java/io/github/jmkeyes/spring/boot/thrift/server/ThriftController.java
+++ b/src/main/java/io/github/jmkeyes/spring/boot/thrift/server/ThriftController.java
@@ -5,6 +5,9 @@ import org.apache.thrift.protocol.TProtocolFactory;
 
 import java.lang.annotation.*;
 
+/**
+ * An annotation to mark the class as a Thrift service controller.
+ */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
@@ -12,11 +15,15 @@ import java.lang.annotation.*;
 public @interface ThriftController {
     /**
      * At least one URL mapping under which this Thrift service should be available.
+     *
+     * @return At least one {@link String} path to mount the servlet at.
      */
     String[] value() default {};
 
     /**
      * The protocol factory this Thrift service should communicate with.
+     *
+     * @return The {@link TProtocolFactory} this Thrift service should use.
      */
     Class<? extends TProtocolFactory> protocolFactory() default TJSONProtocol.Factory.class;
 }


### PR DESCRIPTION
This PR adds some missing Javadocs missed during the 1.0.0 release process.