### PR TITLE
Fix dependabot update dependency ignores on 1.x branch.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,5 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "org.springframework.boot:spring-boot-starter"
+      - dependency-name: "org.springframework.boot:spring-boot-starter-parent"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This PR fixes the dependabot configuration to ignore major version updates of Spring Boot on the `1.x` branch. 